### PR TITLE
Use SHA256 hash function in ECDSA transaction signature

### DIFF
--- a/test/wallet_test.py
+++ b/test/wallet_test.py
@@ -1,9 +1,9 @@
 from wallet import send_transaction
 
 if __name__ == '__main__':
-    addr_from = "uWiVRoaGGKjH/WUcDyumsv05g0Y/o2qa1so9vcBMhm1cKwVJlefQ5O45SBEjykJSjwv1NV/qB6I0dnHR+ciF2Q=="
-    addr_to = "uWiVRoaGGKjH/WUcDyumsv05g0Y/o2qa1so9vcBMhm1cKwVJlefQ5O45SBEjykJSjwv1NV/qB6I0dnHR+ciF2Q=="
-    tx_private_key = "54aa2dbfed1ccf4d8377501a0b26e23b703300397a3f13f4895fc08311fefc73"
+    addr_from = "2NFbCmn8O7stZ8cJTo8rKXGCs8ZaIry1eBZk5XAzI6w0KorYSAQV1Hi20C8Sa6/3vfwY7gq4ZBdfHUWHfqZDcA=="
+    addr_to = "2NFbCmn8O7stZ8cJTo8rKXGCs8ZaIry1eBZk5XAzI6w0KorYSAQV1Hi20C8Sa6/3vfwY7gq4ZBdfHUWHfqZDcA=="
+    tx_private_key = "6ab791fa693fd54066f88de0e794fc660e7b243155b4bcbde5aaf16844941589"
     message = "I have a secret"
     lock_time = 120
     send_transaction(addr_from, tx_private_key, addr_to, 1, message, lock_time)

--- a/test_miner.txt
+++ b/test_miner.txt
@@ -1,2 +1,2 @@
-Private key: 54aa2dbfed1ccf4d8377501a0b26e23b703300397a3f13f4895fc08311fefc73
-Wallet address / Public key: uWiVRoaGGKjH/WUcDyumsv05g0Y/o2qa1so9vcBMhm1cKwVJlefQ5O45SBEjykJSjwv1NV/qB6I0dnHR+ciF2Q==
+Private key: 6ab791fa693fd54066f88de0e794fc660e7b243155b4bcbde5aaf16844941589
+Wallet address / Public key: 2NFbCmn8O7stZ8cJTo8rKXGCs8ZaIry1eBZk5XAzI6w0KorYSAQV1Hi20C8Sa6/3vfwY7gq4ZBdfHUWHfqZDcA==

--- a/wallet.py
+++ b/wallet.py
@@ -18,6 +18,7 @@ transaction with same timestamp was added, they should remove it from the
 node_pending_transactions list to avoid it get processed more than 1 time.
 """
 
+import json
 import requests
 import crypto.elgamal as elgamal
 from os import environ
@@ -97,7 +98,8 @@ def send_transaction(addr_from, private_key, addr_to, amount, msg=None, lock_tim
                 "addr_to": addr_to,
                 "amount": amount,
         }
-        signature = sign_ecdsa_data(private_key, data)
+        tx_json = json.dumps(data, separators=(',', ':'))
+        signature = sign_ecdsa_data(private_key, tx_json)
         url = MINER_NODE_URL + '/txion'
         # decode signature bytes into utf-8 string
         data["signature"] = signature.decode()


### PR DESCRIPTION
to make the Python server/miner being compatible with rust frontend code, the ecdsa use sha256 hash function instead of sha1.

minor mod on tx_sign.py interface
add plain text response for txion http request